### PR TITLE
fix: download_history.py の重複した __main__ ブロックを削除

### DIFF
--- a/src/download_history.py
+++ b/src/download_history.py
@@ -82,6 +82,3 @@ def download_5years_history():
 
 if __name__ == "__main__":
     download_5years_history()
-
-if __name__ == "__main__":
-    download_5years_history()


### PR DESCRIPTION
## 概要
`src/download_history.py` 末尾に `if __name__ == "__main__":` ブロックが2つ定義されていたため、重複している2つ目を削除しました。

Close #4