### PR TITLE
fix: get_default_locations() の東海エントリを補完

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -157,7 +157,7 @@ def get_default_locations() -> list[dict]:
         {"area_name": "九州", "prec_no": 82, "prec_name": "福岡", "block_no": 47807, "block_name": "福岡"},
         {"area_name": "四国", "prec_no": 72, "prec_name": "香川", "block_no": 47891, "block_name": "高松"},
         {"area_name": "中国", "prec_no": 67, "prec_name": "広島", "block_no": 47765, "block_name": "広島"},
-        {"area_name": "東海", "prec_no": 51, }
+        {"area_name": "東海", "prec_no": 51, "prec_name": "愛知", "block_no": 47636, "block_name": "名古屋"},
     ]
 
 


### PR DESCRIPTION
## 概要

`get_default_locations()` 内の東海エントリが途中で切れていたため、不足していたフィールドを補完しました。

## 変更点

- `prec_name`・`block_no`・`block_name` を追加（愛知県・名古屋）

## 影響範囲

`JMA_LOCATIONS` 環境変数未設定時のデフォルト地点リストに名古屋が正しく含まれるようになります。

## テスト

なし

## 動作確認

- [ ] `get_default_locations()` が6地点を返すことを確認

## 関連 issue

Close #3