### PR TITLE
fix: CSV 出力先を data/ ディレクトリに変更

### DIFF
--- a/src/download_history.py
+++ b/src/download_history.py
@@ -69,7 +69,7 @@ def download_5years_history():
         master_df = pd.concat(all_dfs, ignore_index=True)
         
         # CSVファイルに出力
-        output_file = "weather_history_5y.csv"
+        output_file = "../data/weather_history_5y.csv"
         # utf-8-sig を使うとExcelで開いた際の文字化けを防げます
         master_df.to_csv(output_file, index=False, encoding="utf-8-sig")
         


### PR DESCRIPTION
## 概要

`download_history.py` の CSV 出力先が `src/` と同じディレクトリになっていたため、`data/` ディレクトリに変更しました。

## 変更点

- 出力先を `weather_history_5y.csv` から `../data/weather_history_5y.csv` に変更

## 影響範囲

`src/` から実行した場合、CSV が `data/` に出力されるようになります。`data/` は `.gitignore` で除外済みのため、CSV が誤って追跡されることがなくなります。

## テスト

なし

## 動作確認

- [ ] `src/` から実行後、`data/weather_history_5y.csv` が生成されることを確認

## 関連 issue

Close #6