### PR TITLE
refactor: download_history.py のハードコード地点を get_locations_from_env() に統一

### DIFF
--- a/src/download_history.py
+++ b/src/download_history.py
@@ -8,7 +8,7 @@ import time
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import pandas as pd
-from main import fetch_and_validate_weather
+from main import fetch_and_validate_weather, get_locations_from_env
 
 # ロギング設定
 logging.basicConfig(
@@ -18,61 +18,59 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 def download_5years_history():
-    """現在から遡って5年分のデータを取得し、1つのCSVに保存する。"""
-    
-    # 地点設定（デフォルト: 東京）
-    prec_no = 44
-    prec_name = "東京"
-    block_no = 47662
-    block_name = "東京"
-    
-    # 5年分の月数を計算（60ヶ月）
-    # 実行月の前月（または今月）から遡る
+    """現在から遡って5年分のデータを全地点分取得し、1つのCSVに保存する。"""
+
+    locations = get_locations_from_env()
+
     end_date = datetime.now()
     start_date = end_date - relativedelta(years=5)
-    
-    logger.info("%s から %s までのデータを取得します。", 
-                start_date.strftime("%Y/%m"), 
-                end_date.strftime("%Y/%m"))
-    
+
+    logger.info("%s から %s までのデータを取得します。（%d地点）",
+                start_date.strftime("%Y/%m"),
+                end_date.strftime("%Y/%m"),
+                len(locations))
+
     all_dfs = []
     current_date = start_date
-    
+
     while current_date <= end_date:
         year, month = current_date.year, current_date.month
-        
-        try:
-            # main.py のバリデーション済み取得関数を使用
-            df = fetch_and_validate_weather(
-                prec_no, prec_name, block_no, block_name, year, month
-            )
-            
-            if not df.empty:
-                all_dfs.append(df)
-                logger.info("%04d/%02d: %d件のデータを取得完了", 
-                            year, month, len(df))
-            else:
-                logger.warning("%04d/%02d: データがありませんでした", year, month)
-                
-            # サーバー負荷軽減のための待機
-            time.sleep(1)
-            
-        except Exception as e:
-            logger.error("%04d/%02d の取得中にエラーが発生しました: %s", 
-                         year, month, e)
-        
-        # 次の月へ
+
+        for loc in locations:
+            try:
+                df = fetch_and_validate_weather(
+                    loc["prec_no"],
+                    loc["prec_name"],
+                    loc["block_no"],
+                    loc["block_name"],
+                    year,
+                    month,
+                )
+
+                if not df.empty:
+                    all_dfs.append(df)
+                    logger.info("%04d/%02d %s: %d件のデータを取得完了",
+                                year, month, loc["block_name"], len(df))
+                else:
+                    logger.warning("%04d/%02d %s: データがありませんでした",
+                                   year, month, loc["block_name"])
+
+                # サーバー負荷軽減のための待機
+                time.sleep(1)
+
+            except Exception as e:
+                logger.error("%04d/%02d %s の取得中にエラーが発生しました: %s",
+                             year, month, loc.get("block_name"), e)
+
         current_date += relativedelta(months=1)
 
     if all_dfs:
-        # すべてのデータを結合
         master_df = pd.concat(all_dfs, ignore_index=True)
-        
-        # CSVファイルに出力
+
         output_file = "../data/weather_history_5y.csv"
         # utf-8-sig を使うとExcelで開いた際の文字化けを防げます
         master_df.to_csv(output_file, index=False, encoding="utf-8-sig")
-        
+
         logger.info("-" * 30)
         logger.info("全ての処理が完了しました。")
         logger.info("保存先: %s", output_file)


### PR DESCRIPTION
## 概要

`download_history.py` に東京の地点情報がハードコードされていたため、`get_locations_from_env()` を使って全地点を対象に処理するよう変更しました。

## 変更点

- ハードコードされていた東京の地点情報（`prec_no`・`prec_name`・`block_no`・`block_name`）を削除
- `get_locations_from_env()` をインポートし、全地点をループ処理するよう変更
- ログに地点名を追加し、どの地点のデータかが分かるよう改善

## 影響範囲

`download_history.py` 実行時に、`JMA_LOCATIONS` 環境変数またはデフォルト地点（6地点）すべての履歴データが取得されるようになります。

## テスト

なし

## 動作確認

- [ ] デフォルト地点（6地点）で `data/weather_history_5y.csv` が生成されることを確認

## 関連 issue

Close #18