### PR TITLE
docs: 全関数の docstring を Google 形式に統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,3 +40,25 @@ feat: weather_ingestion_handler を複数地点対応にする (#5)
 - ベースブランチは `main`
 - 本文に `Close #<issue番号>` を記載して issue と紐づける
 - マージはユーザーが GitHub 上で行う
+
+## コーディング規約
+
+### docstring
+- すべての関数・クラスに docstring を記載する
+- スタイルは **Google 形式** を使用する
+- `Args`・`Returns`・`Raises` セクションを必要に応じて記載する
+
+```python
+def example(value: int) -> str:
+    """関数の概要を1行で書く。
+
+    Args:
+        value (int): 引数の説明。
+
+    Returns:
+        str: 戻り値の説明。
+
+    Raises:
+        ValueError: 例外が発生する条件の説明。
+    """
+```

--- a/src/bigquery_client.py
+++ b/src/bigquery_client.py
@@ -15,7 +15,21 @@ def delete_month_data(
     year: int,
     month: int,
 ) -> None:
-    """指定した年月の既存データを BigQuery から削除する。"""
+    """指定した年月の既存データを BigQuery から削除する。
+
+    冪等性を担保するため、アップロード前に当月分のデータを削除する。
+
+    Args:
+        client (bigquery.Client): BigQuery クライアント。
+        table_full_id (str): 対象テーブルのフル ID
+            （例: `project.dataset.table`）。
+        year (int): 削除対象の年。
+        month (int): 削除対象の月。
+
+    Raises:
+        google.cloud.exceptions.GoogleCloudError: BigQuery へのクエリが
+            失敗した場合。
+    """
     date_prefix = f"{year}-{month:02d}-"
     delete_query = f"""
         DELETE FROM `{table_full_id}`
@@ -34,7 +48,20 @@ def upload_to_bigquery(
     table_id: str,
     table_full_id: str,
 ) -> None:
-    """DataFrame を BigQuery テーブルへ追記アップロードする。"""
+    """DataFrame を BigQuery テーブルへ追記アップロードする。
+
+    Args:
+        df (pd.DataFrame): アップロード対象のデータフレーム。
+        project_id (str): GCP プロジェクト ID。
+        dataset_id (str): BigQuery データセット ID。
+        table_id (str): BigQuery テーブル ID。
+        table_full_id (str): ログ出力用のフル ID
+            （例: `project.dataset.table`）。
+
+    Raises:
+        google.cloud.exceptions.GoogleCloudError: アップロードが
+            失敗した場合。
+    """
     logger.info(
         "%d 行のデータを %s へアップロード中 (追記)...",
         len(df),

--- a/src/config.py
+++ b/src/config.py
@@ -8,10 +8,28 @@ logger = logging.getLogger(__name__)
 
 
 def get_env_str(key: str, default: str = "") -> str:
+    """環境変数を文字列として取得する。
+
+    Args:
+        key (str): 環境変数名。
+        default (str): 環境変数が未設定の場合のデフォルト値。
+
+    Returns:
+        str: 環境変数の値。未設定の場合は default を返す。
+    """
     return os.getenv(key, default)
 
 
 def parse_location_json(locations_json: str) -> list[dict]:
+    """JSON 文字列を地点設定のリストにパースする。
+
+    Args:
+        locations_json (str): 地点設定を表す JSON 文字列。
+
+    Returns:
+        list[dict]: 地点設定の辞書リスト。
+            パースに失敗した場合は空リストを返す。
+    """
     try:
         return json.loads(locations_json)
     except Exception as e:
@@ -20,6 +38,12 @@ def parse_location_json(locations_json: str) -> list[dict]:
 
 
 def get_default_locations() -> list[dict]:
+    """デフォルトの観測地点リストを返す。
+
+    Returns:
+        list[dict]: area_name・prec_no・prec_name・block_no・block_name
+            を含む地点設定の辞書リスト。
+    """
     return [
         {
             "area_name": "首都圏",
@@ -67,6 +91,14 @@ def get_default_locations() -> list[dict]:
 
 
 def get_locations_from_env() -> list[dict]:
+    """環境変数または デフォルト値から観測地点リストを取得する。
+
+    環境変数 JMA_LOCATIONS に有効な JSON が設定されている場合はそれを使用し、
+    未設定または不正な場合はデフォルト地点リストを返す。
+
+    Returns:
+        list[dict]: 地点設定の辞書リスト。
+    """
     locations_json = get_env_str("JMA_LOCATIONS")
     if locations_json:
         locations = parse_location_json(locations_json)

--- a/src/download_history.py
+++ b/src/download_history.py
@@ -18,7 +18,16 @@ logger = logging.getLogger(__name__)
 
 
 def download_5years_history() -> None:
-    """現在から遡って5年分のデータを全地点分取得し、1つのCSVに保存する。"""
+    """現在から遡って5年分のデータを全地点分取得し、1つのCSVに保存する。
+
+    取得対象地点は環境変数 JMA_LOCATIONS または
+    デフォルト地点リストから取得する。
+    出力先は `../data/weather_history_5y.csv`（utf-8-sig エンコード）。
+    気象庁サーバーへの負荷軽減のため、地点ごとに1秒の待機を挟む。
+
+    Returns:
+        None
+    """
     locations = get_locations_from_env()
 
     end_date = datetime.now()

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -24,7 +24,18 @@ _META_KEYS = {
 
 
 def _fetch_html(url: str) -> str:
-    """気象庁のURLからHTMLを取得する。"""
+    """気象庁のURLからHTMLを取得する。
+
+    Args:
+        url (str): 取得対象の URL。
+
+    Returns:
+        str: レスポンスの HTML テキスト。
+
+    Raises:
+        requests.HTTPError: HTTP エラーが発生した場合。
+        requests.Timeout: リクエストがタイムアウトした場合。
+    """
     response = requests.get(url, timeout=15)
     response.encoding = response.apparent_encoding
     response.raise_for_status()
@@ -32,7 +43,19 @@ def _fetch_html(url: str) -> str:
 
 
 def _parse_weather_table(html: str, year: int, month: int) -> pd.DataFrame:
-    """HTMLから気象テーブルをパースし、フラットなカラムを持つDataFrameを返す。"""
+    """HTMLから気象テーブルをパースし、フラットなカラムを持つDataFrameを返す。
+
+    Args:
+        html (str): 気象庁ページの HTML テキスト。
+        year (int): 取得対象の年（エラーメッセージ用）。
+        month (int): 取得対象の月（エラーメッセージ用）。
+
+    Returns:
+        pd.DataFrame: フラット化されたカラム名を持つ気象データの DataFrame。
+
+    Raises:
+        ValueError: HTML 内に気象テーブルが見つからない場合。
+    """
     soup = BeautifulSoup(html, "lxml")
     table = soup.find("table", class_="data2_s")
     if not table:
@@ -61,7 +84,23 @@ def _validate_weather_records(
     year: int,
     month: int,
 ) -> list[dict]:
-    """DataFrameの各行をPydanticでバリデーションし、有効なレコードのリストを返す。"""
+    """DataFrameの各行をPydanticでバリデーションし、有効なレコードのリストを返す。
+
+    日付が空・不正な行や、観測値が1つも存在しない行（未来日付など）はスキップする。
+
+    Args:
+        df (pd.DataFrame): パース済みの気象データ DataFrame。
+        prec_no (int): 都道府県番号。
+        prec_name (str): 都道府県名。
+        block_no (int): 地点番号。
+        block_name (str): 地点名。
+        area_name (str): エリア名。
+        year (int): 取得対象の年。
+        month (int): 取得対象の月。
+
+    Returns:
+        list[dict]: バリデーション済みの気象レコードの辞書リスト。
+    """
     validated_records = []
 
     for record in df.to_dict(orient="records"):
@@ -92,7 +131,7 @@ def _validate_weather_records(
             if any(v is not None for v in obs_values):
                 validated_records.append(data_dict)
 
-        except ValueError, ValidationError:
+        except (ValueError, ValidationError):
             continue
 
     return validated_records
@@ -120,6 +159,11 @@ def fetch_and_validate_weather(
 
     Returns:
         pd.DataFrame: 指定された月のバリデーション済み気象データ。
+            有効なレコードが存在しない場合は空の DataFrame を返す。
+
+    Raises:
+        requests.HTTPError: 気象庁へのリクエストが失敗した場合。
+        ValueError: HTML 内に気象テーブルが見つからない場合。
     """
     url = (
         f"https://www.data.jma.go.jp/stats/etrn/view/daily_s1.php?"

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -131,7 +131,9 @@ def _validate_weather_records(
             if any(v is not None for v in obs_values):
                 validated_records.append(data_dict)
 
-        except (ValueError, ValidationError):
+        except ValueError:
+            continue
+        except ValidationError:
             continue
 
     return validated_records


### PR DESCRIPTION
## 概要

全モジュールの docstring を Google 形式（Args・Returns・Raises セクションあり）に統一しました。あわせて CLAUDE.md にコーディング規約として明記しました。

## 変更点

- `CLAUDE.md` に Google 形式 docstring の規約を追記
- `config.py`: `get_env_str`・`parse_location_json`・`get_default_locations`・`get_locations_from_env` に docstring を追加
- `scraper.py`: `_fetch_html`・`_parse_weather_table`・`_validate_weather_records`・`fetch_and_validate_weather` の docstring を Google 形式に整備
- `bigquery_client.py`: `delete_month_data`・`upload_to_bigquery` の docstring を Google 形式に整備
- `download_history.py`: `download_5years_history` の docstring を Google 形式に整備

## 影響範囲

ドキュメントのみの変更です。動作への影響はありません。

## テスト

なし

## 動作確認

- [ ] CI の lint チェックが通ることを確認

## 関連 issue

Close #27