### PR TITLE
refactor: Location Pydantic モデルを導入し地点設定を型安全化する

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -4,6 +4,8 @@ import json
 import logging
 import os
 
+from models import Location
+
 logger = logging.getLogger(__name__)
 
 
@@ -20,84 +22,84 @@ def get_env_str(key: str, default: str = "") -> str:
     return os.getenv(key, default)
 
 
-def parse_location_json(locations_json: str) -> list[dict]:
-    """JSON 文字列を地点設定のリストにパースする。
+def parse_location_json(locations_json: str) -> list[Location]:
+    """JSON 文字列を Location モデルのリストにパースする。
 
     Args:
         locations_json (str): 地点設定を表す JSON 文字列。
 
     Returns:
-        list[dict]: 地点設定の辞書リスト。
-            パースに失敗した場合は空リストを返す。
+        list[Location]: Location モデルのリスト。
+            パースまたはバリデーションに失敗した場合は空リストを返す。
     """
     try:
-        return json.loads(locations_json)
-    except json.JSONDecodeError as e:
+        raw_list = json.loads(locations_json)
+        return [Location.model_validate(item) for item in raw_list]
+    except (json.JSONDecodeError, Exception) as e:
         logger.error("JMA_LOCATIONSのパースに失敗: %s", e)
         return []
 
 
-def get_default_locations() -> list[dict]:
+def get_default_locations() -> list[Location]:
     """デフォルトの観測地点リストを返す。
 
     Returns:
-        list[dict]: area_name・prec_no・prec_name・block_no・block_name
-            を含む地点設定の辞書リスト。
+        list[Location]: デフォルトの観測地点の Location モデルリスト。
     """
     return [
-        {
-            "area_name": "首都圏",
-            "prec_no": 44,
-            "prec_name": "東京",
-            "block_no": 47662,
-            "block_name": "東京",
-        },
-        {
-            "area_name": "近畿",
-            "prec_no": 62,
-            "prec_name": "大阪",
-            "block_no": 47772,
-            "block_name": "大阪",
-        },
-        {
-            "area_name": "九州",
-            "prec_no": 82,
-            "prec_name": "福岡",
-            "block_no": 47807,
-            "block_name": "福岡",
-        },
-        {
-            "area_name": "四国",
-            "prec_no": 72,
-            "prec_name": "香川",
-            "block_no": 47891,
-            "block_name": "高松",
-        },
-        {
-            "area_name": "中国",
-            "prec_no": 67,
-            "prec_name": "広島",
-            "block_no": 47765,
-            "block_name": "広島",
-        },
-        {
-            "area_name": "東海",
-            "prec_no": 51,
-            "prec_name": "愛知",
-            "block_no": 47636,
-            "block_name": "名古屋",
-        },
+        Location(
+            area_name="首都圏",
+            prec_no=44,
+            prec_name="東京",
+            block_no=47662,
+            block_name="東京",
+        ),
+        Location(
+            area_name="近畿",
+            prec_no=62,
+            prec_name="大阪",
+            block_no=47772,
+            block_name="大阪",
+        ),
+        Location(
+            area_name="九州",
+            prec_no=82,
+            prec_name="福岡",
+            block_no=47807,
+            block_name="福岡",
+        ),
+        Location(
+            area_name="四国",
+            prec_no=72,
+            prec_name="香川",
+            block_no=47891,
+            block_name="高松",
+        ),
+        Location(
+            area_name="中国",
+            prec_no=67,
+            prec_name="広島",
+            block_no=47765,
+            block_name="広島",
+        ),
+        Location(
+            area_name="東海",
+            prec_no=51,
+            prec_name="愛知",
+            block_no=47636,
+            block_name="名古屋",
+        ),
     ]
 
 
-def get_locations_from_env() -> list[dict]:
-    """環境変数または デフォルト値から観測地点リストを取得する。
+def get_locations_from_env() -> list[Location]:
+    """環境変数またはデフォルト値から観測地点リストを取得する。
 
     環境変数 JMA_LOCATIONS に有効な JSON が設定されている場合はそれを使用し、
     未設定または不正な場合はデフォルト地点リストを返す。
 
     Returns:
-        list[dict]: 地点設定の辞書リスト。
+        list[Location]: 観測地点の Location モデルリスト。
     """
     locations_json = get_env_str("JMA_LOCATIONS")
     if locations_json:

--- a/src/download_history.py
+++ b/src/download_history.py
@@ -49,11 +49,7 @@ def download_5years_history() -> None:
         for loc in locations:
             try:
                 df = fetch_and_validate_weather(
-                    prec_no=loc["prec_no"],
-                    prec_name=loc["prec_name"],
-                    block_no=loc["block_no"],
-                    block_name=loc["block_name"],
-                    area_name=loc["area_name"],
+                    location=loc,
                     year=year,
                     month=month,
                 )
@@ -64,7 +60,7 @@ def download_5years_history() -> None:
                         "%04d/%02d %s: %d件のデータを取得完了",
                         year,
                         month,
-                        loc["block_name"],
+                        loc.block_name,
                         len(df),
                     )
                 else:
@@ -72,7 +68,7 @@ def download_5years_history() -> None:
                         "%04d/%02d %s: データがありませんでした",
                         year,
                         month,
-                        loc["block_name"],
+                        loc.block_name,
                     )
 
                 time.sleep(1)
@@ -82,7 +78,7 @@ def download_5years_history() -> None:
                     "%04d/%02d %s の取得中にエラーが発生しました: %s",
                     year,
                     month,
-                    loc.get("block_name"),
+                    loc.block_name,
                     e,
                 )
 

--- a/src/main.py
+++ b/src/main.py
@@ -53,20 +53,14 @@ def weather_ingestion_handler(request: object = None) -> tuple[str, int]:
     for loc in locations:
         try:
             df = fetch_and_validate_weather(
-                prec_no=loc["prec_no"],
-                prec_name=loc["prec_name"],
-                block_no=loc["block_no"],
-                block_name=loc["block_name"],
-                area_name=loc["area_name"],
+                location=loc,
                 year=year,
                 month=month,
             )
             if not df.empty:
                 all_dfs.append(df)
         except Exception:
-            logger.exception(
-                "%s のデータ取得に失敗しました。", loc.get("block_name")
-            )
+            logger.exception("%s のデータ取得に失敗しました。", loc.block_name)
 
     if not all_dfs:
         return f"{year}/{month} のアップロード対象データがありません", 200

--- a/src/models.py
+++ b/src/models.py
@@ -6,6 +6,16 @@ import pandas as pd
 from pydantic import BaseModel, Field, field_validator
 
 
+class Location(BaseModel):
+    """気象庁の観測地点を定義するモデル。"""
+
+    area_name: str
+    prec_no: int
+    prec_name: str
+    block_no: int
+    block_name: str
+
+
 class WeatherRecord(BaseModel):
     """気象庁の1日あたりの気象データを定義するスキーマ。"""
 

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -9,7 +9,7 @@ import requests
 from bs4 import BeautifulSoup
 from pydantic import ValidationError
 
-from models import WeatherRecord
+from models import Location, WeatherRecord
 
 logger = logging.getLogger(__name__)
 
@@ -76,11 +76,7 @@ def _parse_weather_table(html: str, year: int, month: int) -> pd.DataFrame:
 
 def _validate_weather_records(
     df: pd.DataFrame,
-    prec_no: int,
-    prec_name: str,
-    block_no: int,
-    block_name: str,
-    area_name: str,
+    location: Location,
     year: int,
     month: int,
 ) -> list[dict]:
@@ -90,11 +86,7 @@ def _validate_weather_records(
 
     Args:
         df (pd.DataFrame): パース済みの気象データ DataFrame。
-        prec_no (int): 都道府県番号。
-        prec_name (str): 都道府県名。
-        block_no (int): 地点番号。
-        block_name (str): 地点名。
-        area_name (str): エリア名。
+        location (Location): 観測地点情報。
         year (int): 取得対象の年。
         month (int): 取得対象の月。
 
@@ -114,11 +106,11 @@ def _validate_weather_records(
             day_int = int(float(day_val))
             current_date = date(year, month, day_int)
             record["date"] = current_date.isoformat()
-            record["area_name"] = area_name
-            record["prec_no"] = str(prec_no)
-            record["prec_name"] = prec_name
-            record["block_no"] = str(block_no)
-            record["block_name"] = block_name
+            record["area_name"] = location.area_name
+            record["prec_no"] = str(location.prec_no)
+            record["prec_name"] = location.prec_name
+            record["block_no"] = str(location.block_no)
+            record["block_name"] = location.block_name
 
             v_record = WeatherRecord(**record)
             data_dict = v_record.model_dump()
@@ -140,22 +132,14 @@ def _validate_weather_records(
 
 
 def fetch_and_validate_weather(
-    prec_no: int,
-    prec_name: str,
-    block_no: int,
-    block_name: str,
-    area_name: str,
+    location: Location,
     year: int,
     month: int,
 ) -> pd.DataFrame:
     """気象庁からデータを取得し、Pydanticでバリデーションを行う。
 
     Args:
-        prec_no (int): 都道府県番号。
-        prec_name (str): 都道府県名。
-        block_no (int): 地点番号。
-        block_name (str): 地点名。
-        area_name (str): エリア名。
+        location (Location): 観測地点情報。
         year (int): 取得対象の年。
         month (int): 取得対象の月。
 
@@ -169,16 +153,14 @@ def fetch_and_validate_weather(
     """
     url = (
         f"https://www.data.jma.go.jp/stats/etrn/view/daily_s1.php?"
-        f"prec_no={prec_no}&block_no={block_no}&"
+        f"prec_no={location.prec_no}&block_no={location.block_no}&"
         f"year={year}&month={month:02d}&day=&view=p1"
     )
 
     logger.info("%04d/%02d のデータを取得中: %s", year, month, url)
     html = _fetch_html(url)
     df = _parse_weather_table(html, year, month)
-    validated_records = _validate_weather_records(
-        df, prec_no, prec_name, block_no, block_name, area_name, year, month
-    )
+    validated_records = _validate_weather_records(df, location, year, month)
 
     if not validated_records:
         logger.warning(


### PR DESCRIPTION
## 概要

- `models.py` に `Location` Pydantic `BaseModel` を追加
- `config.py` の各関数の戻り値を `list[dict]` から `list[Location]` に変更
- `scraper.py` の `_validate_weather_records` / `fetch_and_validate_weather` の引数を `Location` モデル 1 つに集約（ruff PLR0913 解消）
- `main.py` / `download_history.py` を `Location` 型に合わせて更新

## 変更ファイル

- `src/models.py` — `Location` モデル追加
- `src/config.py` — 戻り値型を `list[Location]` に変更、`Location.model_validate()` / `Location(...)` コンストラクタ使用
- `src/scraper.py` — 引数を `location: Location` 1 つに統合
- `src/main.py` — `loc.block_name` など属性アクセスに変更
- `src/download_history.py` — 同上

## テスト計画

- [ ] `uv run ruff check src/` がエラーなしで通ること
- [ ] `uv run ruff format --check src/` がエラーなしで通ること
- [ ] CI（GitHub Actions lint）がグリーンになること

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)