### PR TITLE
test: models.py と config.py のユニットテストを追加する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.3",
     "ruff>=0.15.5",
 ]
 
@@ -45,3 +46,7 @@ known-first-party = ["main"]
 
 [tool.ruff.format]
 docstring-code-line-length = 72
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,112 @@
+"""config.py のユニットテスト。"""
+
+import pytest
+
+from config import (
+    get_default_locations,
+    get_locations_from_env,
+    parse_location_json,
+)
+from models import Location
+
+
+class TestParseLocationJson:
+    """parse_location_json のテスト。"""
+
+    def test_valid_json_returns_locations(self):
+        """正常な JSON 文字列から Location リストを返す。"""
+        json_str = (
+            '[{"area_name": "首都圏", "prec_no": 44,'
+            ' "prec_name": "東京", "block_no": 47662,'
+            ' "block_name": "東京"}]'
+        )
+        result = parse_location_json(json_str)
+        assert len(result) == 1
+        assert isinstance(result[0], Location)
+        assert result[0].block_name == "東京"
+
+    def test_multiple_locations(self):
+        """複数地点の JSON を正しくパースできる。"""
+        json_str = (
+            '[{"area_name": "首都圏", "prec_no": 44,'
+            ' "prec_name": "東京", "block_no": 47662,'
+            ' "block_name": "東京"},'
+            ' {"area_name": "近畿", "prec_no": 62,'
+            ' "prec_name": "大阪", "block_no": 47772,'
+            ' "block_name": "大阪"}]'
+        )
+        result = parse_location_json(json_str)
+        assert len(result) == 2
+        assert result[1].block_name == "大阪"
+
+    def test_invalid_json_returns_empty_list(self):
+        """不正な JSON 文字列は空リストを返す。"""
+        result = parse_location_json("not a json")
+        assert result == []
+
+    def test_missing_required_field_returns_empty_list(self):
+        """必須フィールドが欠けた JSON は空リストを返す。"""
+        json_str = '[{"area_name": "首都圏"}]'
+        result = parse_location_json(json_str)
+        assert result == []
+
+    def test_empty_list_json_returns_empty_list(self):
+        """空配列 JSON は空リストを返す。"""
+        result = parse_location_json("[]")
+        assert result == []
+
+
+class TestGetDefaultLocations:
+    """get_default_locations のテスト。"""
+
+    def test_returns_list_of_locations(self):
+        """Location のリストを返す。"""
+        result = get_default_locations()
+        assert isinstance(result, list)
+        assert all(isinstance(loc, Location) for loc in result)
+
+    def test_returns_six_locations(self):
+        """デフォルトは 6 地点を返す。"""
+        result = get_default_locations()
+        assert len(result) == 6
+
+    def test_contains_tokyo(self):
+        """東京が含まれている。"""
+        result = get_default_locations()
+        block_names = [loc.block_name for loc in result]
+        assert "東京" in block_names
+
+    def test_all_have_required_fields(self):
+        """全地点が必須フィールドを持つ。"""
+        for loc in get_default_locations():
+            assert loc.area_name
+            assert loc.prec_no > 0
+            assert loc.block_no > 0
+
+
+class TestGetLocationsFromEnv:
+    """get_locations_from_env のテスト。"""
+
+    def test_returns_default_when_env_not_set(self, monkeypatch):
+        """JMA_LOCATIONS 未設定時はデフォルト地点を返す。"""
+        monkeypatch.delenv("JMA_LOCATIONS", raising=False)
+        result = get_locations_from_env()
+        assert len(result) == 6
+
+    def test_returns_env_locations_when_set(self, monkeypatch):
+        """JMA_LOCATIONS が正常に設定されている場合はその値を返す。"""
+        json_str = (
+            '[{"area_name": "首都圏", "prec_no": 44,'
+            ' "prec_name": "東京", "block_no": 47662,'
+            ' "block_name": "東京"}]'
+        )
+        monkeypatch.setenv("JMA_LOCATIONS", json_str)
+        result = get_locations_from_env()
+        assert len(result) == 1
+        assert result[0].block_name == "東京"
+
+    def test_falls_back_to_default_on_invalid_json(self, monkeypatch):
+        """JMA_LOCATIONS が不正な JSON の場合はデフォルト地点を返す。"""
+        monkeypatch.setenv("JMA_LOCATIONS", "invalid json")
+        result = get_locations_from_env()
+        assert len(result) == 6

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,125 @@
+"""models.py の WeatherRecord / Location モデルのユニットテスト。"""
+
+import pytest
+from pydantic import ValidationError
+
+from models import Location, WeatherRecord
+
+
+class TestCleanJmaSymbols:
+    """WeatherRecord.clean_jma_symbols バリデーターのテスト。
+
+    temperature_mean は alias（気温(℃)_気温(℃)_平均）経由でのみ
+    モデルに渡せるため、バリデーターをクラスメソッドとして直接呼び出す。
+    """
+
+    def test_none_returns_none(self):
+        """None はそのまま None を返す。"""
+        assert WeatherRecord.clean_jma_symbols(None) is None
+
+    def test_nan_returns_none(self):
+        """float NaN は None を返す。"""
+        import math
+
+        assert WeatherRecord.clean_jma_symbols(math.nan) is None
+
+    @pytest.mark.parametrize("symbol", ["--", "×", "///", ""])
+    def test_jma_missing_symbols_return_none(self, symbol):
+        """気象庁の欠損記号は None を返す。"""
+        assert WeatherRecord.clean_jma_symbols(symbol) is None
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("12.3)", "12.3"),
+            ("5.6]", "5.6"),
+            ("7.8*", "7.8"),
+            ("9.0)*", "9.0"),
+        ],
+    )
+    def test_trailing_symbols_are_stripped(self, raw, expected):
+        """末尾の )、]、* は除去される。"""
+        assert WeatherRecord.clean_jma_symbols(raw) == expected
+
+    def test_normal_value_passes_through(self):
+        """通常の数値文字列はそのまま保持される。"""
+        assert WeatherRecord.clean_jma_symbols("15.2") == "15.2"
+
+
+class TestWeatherRecordRequired:
+    """WeatherRecord の必須フィールドのテスト。"""
+
+    def test_missing_required_field_raises(self):
+        """必須フィールドが欠けている場合は ValidationError が発生する。"""
+        with pytest.raises(ValidationError):
+            WeatherRecord(
+                area_name="首都圏",
+                prec_no="44",
+                prec_name="東京",
+                block_no="47662",
+                block_name="東京",
+            )
+
+    def test_all_optional_fields_default_to_none(self):
+        """省略可能フィールドはデフォルトで None になる。"""
+        r = WeatherRecord(
+            date="2024-01-01",
+            area_name="首都圏",
+            prec_no="44",
+            prec_name="東京",
+            block_no="47662",
+            block_name="東京",
+        )
+        assert r.temperature_mean is None
+        assert r.precipitation_total is None
+        assert r.wind_speed_mean is None
+
+
+class TestLocation:
+    """Location モデルのテスト。"""
+
+    def test_valid_location(self):
+        """正常な値で Location が作成できる。"""
+        loc = Location(
+            area_name="首都圏",
+            prec_no=44,
+            prec_name="東京",
+            block_no=47662,
+            block_name="東京",
+        )
+        assert loc.area_name == "首都圏"
+        assert loc.prec_no == 44
+        assert loc.block_no == 47662
+
+    def test_model_validate_from_dict(self):
+        """dict から model_validate で Location が作成できる。"""
+        data = {
+            "area_name": "近畿",
+            "prec_no": 62,
+            "prec_name": "大阪",
+            "block_no": 47772,
+            "block_name": "大阪",
+        }
+        loc = Location.model_validate(data)
+        assert loc.prec_name == "大阪"
+
+    def test_missing_field_raises(self):
+        """必須フィールドが欠けている場合は ValidationError が発生する。"""
+        with pytest.raises(ValidationError):
+            Location(
+                area_name="首都圏",
+                prec_no=44,
+                prec_name="東京",
+                block_no=47662,
+            )
+
+    def test_invalid_type_raises(self):
+        """prec_no に文字列を渡した場合、数値変換できなければ ValidationError。"""
+        with pytest.raises(ValidationError):
+            Location(
+                area_name="首都圏",
+                prec_no="invalid",
+                prec_name="東京",
+                block_no=47662,
+                block_name="東京",
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -97,6 +97,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -326,6 +335,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -355,6 +373,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -372,7 +391,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.5" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.15.5" },
+]
 
 [[package]]
 name = "lxml"
@@ -524,6 +546,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -693,6 +724,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/0d/455cb39f0d5a914412b57c55c6b16977c61a5ac74b615eea4fb0dc54e329/pydata-google-auth-1.9.1.tar.gz", hash = "sha256:0a51ce41c601ca0bc69b8795bf58bedff74b4a6a007c9106c7cbcdec00eaced2", size = 29814, upload-time = "2025-01-23T21:04:40.875Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/cb/cdeaba62aa3c48f0d8834afb82b4a21463cd83df34fe01f9daa89a08ec6c/pydata_google_auth-1.9.1-py2.py3-none-any.whl", hash = "sha256:75ffce5d106e34b717b31844c1639ea505b7d9550dc23b96fb6c20d086b53fa3", size = 15552, upload-time = "2025-01-23T21:04:38.97Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `tests/test_models.py`：`WeatherRecord.clean_jma_symbols` バリデーターと `Location` モデルのユニットテストを追加
- `tests/test_config.py`：`parse_location_json`・`get_default_locations`・`get_locations_from_env` のユニットテストを追加
- `pyproject.toml`：`pytest` を dev 依存に追加し、`[tool.pytest.ini_options]` で `testpaths` と `pythonpath` を設定

Close #32

## Test plan

- [ ] `uv run pytest tests/ -v` で全 29 件がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)