### PR TITLE
test: scraper.py のユニットテストを追加する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "responses>=0.25.3",
     "ruff>=0.15.5",
 ]
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,196 @@
+"""scraper.py のユニットテスト。"""
+
+import unittest.mock as mock
+
+import pandas as pd
+import pytest
+import requests
+import responses as responses_mock
+
+from models import Location
+from scraper import (
+    _fetch_html,
+    _parse_weather_table,
+    _validate_weather_records,
+    fetch_and_validate_weather,
+)
+
+# テスト用の観測地点
+TOKYO = Location(
+    area_name="首都圏",
+    prec_no=44,
+    prec_name="東京",
+    block_no=47662,
+    block_name="東京",
+)
+
+# 最小限の気象テーブル HTML フィクスチャ
+# パース後のカラム名: ["日_日_日", "気温(℃)_気温(℃)_平均"]
+MINIMAL_TABLE_HTML = """<html><body>
+<table class="data2_s">
+  <tr><th rowspan="3">日</th><th>気温(℃)</th></tr>
+  <tr><th>気温(℃)</th></tr>
+  <tr><th>平均</th></tr>
+  <tr><td>1</td><td>15.2</td></tr>
+  <tr><td>2</td><td>16.0</td></tr>
+</table>
+</body></html>"""
+
+# 先頭データ行が「日」の HTML フィクスチャ（1行スキップされる）
+TABLE_HTML_WITH_HI_ROW = """<html><body>
+<table class="data2_s">
+  <tr><th rowspan="3">日</th><th>気温(℃)</th></tr>
+  <tr><th>気温(℃)</th></tr>
+  <tr><th>平均</th></tr>
+  <tr><td>日</td><td>気温(℃)_気温(℃)_平均</td></tr>
+  <tr><td>1</td><td>15.2</td></tr>
+</table>
+</body></html>"""
+
+
+class TestFetchHtml:
+    """_fetch_html のテスト。"""
+
+    @responses_mock.activate
+    def test_success_returns_html(self):
+        """正常なレスポンスは HTML テキストを返す。"""
+        responses_mock.add(
+            responses_mock.GET,
+            "http://example.com/test",
+            body="<html>OK</html>",
+            status=200,
+        )
+        result = _fetch_html("http://example.com/test")
+        assert "<html>" in result
+
+    @responses_mock.activate
+    def test_http_error_raises(self):
+        """HTTP 404 は HTTPError を送出する。"""
+        responses_mock.add(
+            responses_mock.GET,
+            "http://example.com/test",
+            status=404,
+        )
+        with pytest.raises(requests.HTTPError):
+            _fetch_html("http://example.com/test")
+
+    @responses_mock.activate
+    def test_timeout_raises(self):
+        """タイムアウト時は Timeout を送出する。"""
+        responses_mock.add(
+            responses_mock.GET,
+            "http://example.com/test",
+            body=requests.Timeout(),
+        )
+        with pytest.raises(requests.Timeout):
+            _fetch_html("http://example.com/test")
+
+
+class TestParseWeatherTable:
+    """_parse_weather_table のテスト。"""
+
+    def test_valid_html_returns_dataframe(self):
+        """正常な HTML から DataFrame を返す。"""
+        df = _parse_weather_table(MINIMAL_TABLE_HTML, 2024, 1)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2
+
+    def test_columns_are_flattened(self):
+        """マルチレベルのカラムがフラット化される。"""
+        df = _parse_weather_table(MINIMAL_TABLE_HTML, 2024, 1)
+        assert "気温(℃)_気温(℃)_平均" in df.columns
+
+    def test_no_table_raises_value_error(self):
+        """気象テーブルが存在しない場合は ValueError を送出する。"""
+        html = "<html><body><p>テーブルなし</p></body></html>"
+        with pytest.raises(ValueError, match="気象テーブル"):
+            _parse_weather_table(html, 2024, 1)
+
+    def test_first_row_hi_is_skipped(self):
+        """先頭データ行が「日」の場合はスキップされる。"""
+        df = _parse_weather_table(TABLE_HTML_WITH_HI_ROW, 2024, 1)
+        assert len(df) == 1
+        assert df.iloc[0, 0] != "日"
+
+
+class TestValidateWeatherRecords:
+    """_validate_weather_records のテスト。"""
+
+    def _make_df(
+        self,
+        days: list,
+        temp_values: list,
+    ) -> pd.DataFrame:
+        """テスト用 DataFrame を作成するヘルパー。"""
+        return pd.DataFrame(
+            {
+                "日": days,
+                "気温(℃)_気温(℃)_平均": temp_values,
+            }
+        )
+
+    def test_valid_records_returned(self):
+        """正常な行はバリデーション済みレコードとして返される。"""
+        df = self._make_df([1.0, 2.0], ["15.2", "16.0"])
+        records = _validate_weather_records(df, TOKYO, 2024, 1)
+        assert len(records) == 2
+        assert records[0]["temperature_mean"] == "15.2"
+
+    def test_metadata_is_set_correctly(self):
+        """date・area_name 等のメタデータが正しくセットされる。"""
+        df = self._make_df([5.0], ["12.5"])
+        records = _validate_weather_records(df, TOKYO, 2024, 3)
+        assert records[0]["date"] == "2024-03-05"
+        assert records[0]["area_name"] == "首都圏"
+        assert records[0]["prec_name"] == "東京"
+        assert records[0]["block_name"] == "東京"
+
+    def test_nan_day_is_skipped(self):
+        """日付列が NaN の行はスキップされる。"""
+        df = self._make_df([float("nan"), 1.0], [None, "15.2"])
+        records = _validate_weather_records(df, TOKYO, 2024, 1)
+        assert len(records) == 1
+
+    def test_invalid_day_string_is_skipped(self):
+        """日付列が数値変換不可の文字列の行はスキップされる。"""
+        df = self._make_df(["abc", 1.0], ["15.2", "16.0"])
+        records = _validate_weather_records(df, TOKYO, 2024, 1)
+        assert len(records) == 1
+
+    def test_out_of_range_day_is_skipped(self):
+        """存在しない日付（32日など）の行はスキップされる。"""
+        df = self._make_df([32.0, 1.0], ["15.2", "16.0"])
+        records = _validate_weather_records(df, TOKYO, 2024, 1)
+        assert len(records) == 1
+
+    def test_all_obs_none_is_skipped(self):
+        """観測値がすべて None の行はスキップされる（未来日付など）。"""
+        df = self._make_df([15.0], [None])
+        records = _validate_weather_records(df, TOKYO, 2024, 6)
+        assert len(records) == 0
+
+
+class TestFetchAndValidateWeather:
+    """fetch_and_validate_weather のテスト。"""
+
+    def test_success_returns_dataframe(self):
+        """正常系は有効レコードを含む DataFrame を返す。"""
+        with mock.patch("scraper._fetch_html", return_value=MINIMAL_TABLE_HTML):
+            result = fetch_and_validate_weather(TOKYO, 2024, 1)
+        assert isinstance(result, pd.DataFrame)
+        assert not result.empty
+        assert len(result) == 2
+
+    def test_empty_dataframe_when_no_valid_records(self):
+        """有効なレコードがない場合は空の DataFrame を返す。"""
+        with (
+            mock.patch(
+                "scraper._fetch_html", return_value=MINIMAL_TABLE_HTML
+            ),
+            mock.patch(
+                "scraper._validate_weather_records", return_value=[]
+            ),
+        ):
+            result = fetch_and_validate_weather(TOKYO, 2024, 1)
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty

--- a/uv.lock
+++ b/uv.lock
@@ -374,6 +374,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "responses" },
     { name = "ruff" },
 ]
 
@@ -393,6 +394,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "responses", specifier = ">=0.25.3" },
     { name = "ruff", specifier = ">=0.15.5" },
 ]
 
@@ -764,6 +766,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -789,6 +817,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `tests/test_scraper.py`：`scraper.py` の全関数に対するユニットテストを追加（15件）
- `pyproject.toml`：HTTP モック用に `responses>=0.25.3` を dev 依存に追加

### テスト内容

| クラス | テスト対象 | 件数 |
|---|---|---|
| `TestFetchHtml` | 正常系・HTTPError・Timeout | 3 |
| `TestParseWeatherTable` | 正常系・カラムフラット化・テーブルなし・「日」行スキップ | 4 |
| `TestValidateWeatherRecords` | 正常系・メタデータ検証・NaN/不正/範囲外日付スキップ・全観測値Noneスキップ | 6 |
| `TestFetchAndValidateWeather` | 正常系・空DataFrame返却 | 2 |

Close #33

## Test plan

- [ ] `uv run pytest tests/ -v` で全 44 件がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)