### PR TITLE
test: bigquery_client.py と main.py のユニットテストを追加する

### DIFF
--- a/tests/test_bigquery_client.py
+++ b/tests/test_bigquery_client.py
@@ -1,0 +1,81 @@
+"""bigquery_client.py のユニットテスト。"""
+
+import unittest.mock as mock
+
+import pandas as pd
+import pytest
+
+from bigquery_client import delete_month_data, upload_to_bigquery
+
+
+class TestDeleteMonthData:
+    """delete_month_data のテスト。"""
+
+    def test_query_is_called(self):
+        """client.query が1回呼ばれる。"""
+        mock_client = mock.MagicMock()
+        delete_month_data(mock_client, "proj.ds.tbl", 2024, 1)
+        mock_client.query.assert_called_once()
+
+    def test_result_is_called(self):
+        """query().result() が呼ばれる。"""
+        mock_client = mock.MagicMock()
+        delete_month_data(mock_client, "proj.ds.tbl", 2024, 1)
+        mock_client.query.return_value.result.assert_called_once()
+
+    def test_query_contains_date_prefix(self):
+        """クエリに正しい年月プレフィックスが含まれる。"""
+        mock_client = mock.MagicMock()
+        delete_month_data(mock_client, "proj.ds.tbl", 2024, 1)
+        query = mock_client.query.call_args[0][0]
+        assert "2024-01-" in query
+
+    def test_query_contains_table_id(self):
+        """クエリに対象テーブル ID が含まれる。"""
+        mock_client = mock.MagicMock()
+        delete_month_data(mock_client, "proj.ds.tbl", 2024, 1)
+        query = mock_client.query.call_args[0][0]
+        assert "proj.ds.tbl" in query
+
+    @pytest.mark.parametrize(
+        "month, expected_prefix",
+        [(1, "2024-01-"), (12, "2024-12-")],
+    )
+    def test_month_zero_padded(self, month, expected_prefix):
+        """月は2桁ゼロ埋めされる。"""
+        mock_client = mock.MagicMock()
+        delete_month_data(mock_client, "proj.ds.tbl", 2024, month)
+        query = mock_client.query.call_args[0][0]
+        assert expected_prefix in query
+
+
+class TestUploadToBigquery:
+    """upload_to_bigquery のテスト。"""
+
+    def test_to_gbq_is_called(self):
+        """pandas_gbq.to_gbq が1回呼ばれる。"""
+        df = pd.DataFrame({"col": [1, 2]})
+        with mock.patch("bigquery_client.pandas_gbq.to_gbq") as mock_to_gbq:
+            upload_to_bigquery(df, "proj", "ds", "tbl", "proj.ds.tbl")
+        mock_to_gbq.assert_called_once()
+
+    def test_correct_project_id(self):
+        """正しい project_id で呼ばれる。"""
+        df = pd.DataFrame({"col": [1]})
+        with mock.patch("bigquery_client.pandas_gbq.to_gbq") as mock_to_gbq:
+            upload_to_bigquery(df, "my-project", "ds", "tbl", "my-project.ds.tbl")
+        assert mock_to_gbq.call_args.kwargs["project_id"] == "my-project"
+
+    def test_append_mode(self):
+        """if_exists="append" で呼ばれる。"""
+        df = pd.DataFrame({"col": [1]})
+        with mock.patch("bigquery_client.pandas_gbq.to_gbq") as mock_to_gbq:
+            upload_to_bigquery(df, "proj", "ds", "tbl", "proj.ds.tbl")
+        assert mock_to_gbq.call_args.kwargs["if_exists"] == "append"
+
+    def test_progress_bar_disabled(self):
+        """progress_bar=False で呼ばれる。"""
+        df = pd.DataFrame({"col": [1]})
+        with mock.patch("bigquery_client.pandas_gbq.to_gbq") as mock_to_gbq:
+            upload_to_bigquery(df, "proj", "ds", "tbl", "proj.ds.tbl")
+        assert mock_to_gbq.call_args.kwargs["progress_bar"] is False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,91 @@
+"""main.py の weather_ingestion_handler のユニットテスト。"""
+
+import unittest.mock as mock
+
+import pandas as pd
+import pytest
+
+from main import weather_ingestion_handler
+from models import Location
+
+# テスト用の観測地点（単一地点に限定してテストを単純化）
+SINGLE_LOCATION = [
+    Location(
+        area_name="首都圏",
+        prec_no=44,
+        prec_name="東京",
+        block_no=47662,
+        block_name="東京",
+    )
+]
+
+# 有効なレコードを含む DataFrame フィクスチャ
+SAMPLE_DF = pd.DataFrame(
+    {
+        "date": ["2024-01-01", "2024-01-02"],
+        "block_name": ["東京", "東京"],
+    }
+)
+
+
+class TestWeatherIngestionHandler:
+    """weather_ingestion_handler のテスト。"""
+
+    def test_returns_500_when_no_project_id(self, monkeypatch):
+        """GCP_PROJECT_ID 未設定時はステータス 500 を返す。"""
+        monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
+        _, status = weather_ingestion_handler()
+        assert status == 500
+
+    def test_returns_200_with_valid_data(self, monkeypatch):
+        """正常系（データあり）はステータス 200 を返す。"""
+        monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
+        with (
+            mock.patch("main.bigquery.Client"),
+            mock.patch("main.delete_month_data"),
+            mock.patch(
+                "main.get_locations_from_env", return_value=SINGLE_LOCATION
+            ),
+            mock.patch(
+                "main.fetch_and_validate_weather", return_value=SAMPLE_DF
+            ),
+            mock.patch("main.upload_to_bigquery"),
+        ):
+            _, status = weather_ingestion_handler()
+        assert status == 200
+
+    def test_upload_is_called_with_data(self, monkeypatch):
+        """データあり時は upload_to_bigquery が呼ばれる。"""
+        monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
+        with (
+            mock.patch("main.bigquery.Client"),
+            mock.patch("main.delete_month_data"),
+            mock.patch(
+                "main.get_locations_from_env", return_value=SINGLE_LOCATION
+            ),
+            mock.patch(
+                "main.fetch_and_validate_weather", return_value=SAMPLE_DF
+            ),
+            mock.patch("main.upload_to_bigquery") as mock_upload,
+        ):
+            weather_ingestion_handler()
+        mock_upload.assert_called_once()
+
+    def test_returns_200_when_no_data(self, monkeypatch):
+        """全地点でデータなし時はステータス 200 を返す。"""
+        monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
+        with (
+            mock.patch("main.bigquery.Client"),
+            mock.patch("main.delete_month_data"),
+            mock.patch(
+                "main.get_locations_from_env", return_value=SINGLE_LOCATION
+            ),
+            mock.patch(
+                "main.fetch_and_validate_weather",
+                return_value=pd.DataFrame(),
+            ),
+            mock.patch("main.upload_to_bigquery") as mock_upload,
+        ):
+            _, status = weather_ingestion_handler()
+        assert status == 200
+        mock_upload.assert_not_called()


### PR DESCRIPTION
## Summary

- `tests/test_bigquery_client.py`：`delete_month_data`・`upload_to_bigquery` のユニットテストを追加（10件）
- `tests/test_main.py`：`weather_ingestion_handler` のユニットテストを追加（4件）
- `google.cloud.bigquery.Client` と `pandas_gbq.to_gbq` は `unittest.mock` でモック

### テスト内容

| クラス | テスト対象 | 件数 |
|---|---|---|
| `TestDeleteMonthData` | `client.query` 呼び出し・クエリ内容・月のゼロ埋め | 5 |
| `TestUploadToBigquery` | `to_gbq` 呼び出し・`project_id`・`append` モード・`progress_bar` | 4 |  
| `TestWeatherIngestionHandler` | 環境変数未設定の 500・正常系 200・upload 呼び出し・データなし 200 | 4 + 1 |

Close #34

## Test plan

- [ ] `uv run pytest tests/ -v` で全 58 件がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)