### PR TITLE
fix: config.py の冗長な例外ハンドリングを修正する

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -35,7 +35,7 @@ def parse_location_json(locations_json: str) -> list[Location]:
     try:
         raw_list = json.loads(locations_json)
         return [Location.model_validate(item) for item in raw_list]
-    except (json.JSONDecodeError, Exception) as e:
+    except Exception as e:
         logger.error("JMA_LOCATIONSのパースに失敗: %s", e)
         return []
 


### PR DESCRIPTION
## Summary

- `parse_location_json` の `except (json.JSONDecodeError, Exception)` を `except Exception` に修正
- `json.JSONDecodeError` は `Exception` のサブクラスのため、両方指定するのは冗長

Close #38

## Test plan

- [ ] `uv run pytest tests/ -q` で全 58 件がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)