### PR TITLE
fix: download_history.py の出力パスをスクリプト基準の絶対パスに変更する

### DIFF
--- a/src/download_history.py
+++ b/src/download_history.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from datetime import datetime
+from pathlib import Path
 
 import pandas as pd
 from dateutil.relativedelta import relativedelta
@@ -86,7 +87,7 @@ def download_5years_history() -> None:
 
     if all_dfs:
         master_df = pd.concat(all_dfs, ignore_index=True)
-        output_file = "../data/weather_history_5y.csv"
+        output_file = Path(__file__).parent.parent / "data" / "weather_history_5y.csv"
         # utf-8-sig を使うとExcelで開いた際の文字化けを防げます
         master_df.to_csv(output_file, index=False, encoding="utf-8-sig")
 

--- a/src/download_history.py
+++ b/src/download_history.py
@@ -87,7 +87,9 @@ def download_5years_history() -> None:
 
     if all_dfs:
         master_df = pd.concat(all_dfs, ignore_index=True)
-        output_file = Path(__file__).parent.parent / "data" / "weather_history_5y.csv"
+        output_file = (
+            Path(__file__).parent.parent / "data" / "weather_history_5y.csv"
+        )
         # utf-8-sig を使うとExcelで開いた際の文字化けを防げます
         master_df.to_csv(output_file, index=False, encoding="utf-8-sig")
 


### PR DESCRIPTION
## Summary

- `pathlib.Path(__file__).parent.parent / "data" / "weather_history_5y.csv"` を使い、スクリプトファイルの位置を基準とした絶対パスに変更
- 実行ディレクトリに依存せず、どこから実行しても正しい出力先（プロジェクトルートの `data/` ）に保存されるようになる

Close #39

## Test plan

- [ ] `uv run pytest tests/ -q` で全 58 件がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)