### PR TITLE
refactor: scraper.py の重複した例外ハンドラをまとめる

### DIFF
--- a/src/scraper.py
+++ b/src/scraper.py
@@ -123,7 +123,7 @@ def _validate_weather_records(
             if any(v is not None for v in obs_values):
                 validated_records.append(data_dict)
 
-        except (ValueError, ValidationError):
+        except ValueError, ValidationError:
             continue
 
     return validated_records

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -123,9 +123,7 @@ def _validate_weather_records(
             if any(v is not None for v in obs_values):
                 validated_records.append(data_dict)
 
-        except ValueError:
-            continue
-        except ValidationError:
+        except (ValueError, ValidationError):
             continue
 
     return validated_records


### PR DESCRIPTION
## Summary

- `_validate_weather_records` 内の `except ValueError` と `except ValidationError` を `except (ValueError, ValidationError)` に統合
- どちらも `continue` するだけで処理が同一のため、1つにまとめた

Close #40

## Test plan

- [ ] `uv run ruff check src/` でエラーなし
- [ ] `uv run pytest tests/ -q` で全 58 件がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)