### PR TITLE
chore: Docker + Cloud Run Jobs 対応・requirements.txt を廃止する

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# 開発ツール
+.venv/
+.vscode/
+.git/
+.github/
+
+# キャッシュ
+.pytest_cache/
+.ruff_cache/
+__pycache__/
+*.pyc
+*.pyo
+
+# プロジェクト設定・ドキュメント
+CLAUDE.md
+README.md
+mise.toml
+.python-version
+.gitignore
+
+# テスト・開発用ファイル
+tests/
+requirements.txt
+
+# データ
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.14-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+COPY src/ ./src/
+
+ENV PYTHONPATH=/app/src
+
+CMD ["uv", "run", "python", "src/main.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-beautifulsoup4>=4.14.3
-google-cloud-bigquery>=3.40.1
-lxml>=6.0.2
-pandas>=3.0.1
-pandas-gbq>=0.34.0
-pydantic>=2.12.5
-requests>=2.32.5

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,8 @@
-"""気象庁の気象データを取得し、BigQueryにアップロードするCloud Function。
-
-実行時の日付から自動的に対象の年月を特定し、気象庁からデータを取得します。
-Pydantic でバリデーションを行い、BigQuery のテーブルを更新します。
-"""
+"""気象庁データを取得し、BigQuery へアップロードする Cloud Run Jobs 処理。"""
 
 import logging
 import os
+import sys
 from datetime import datetime, timedelta
 
 import pandas as pd
@@ -19,22 +16,22 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def weather_ingestion_handler(request: object = None) -> tuple[str, int]:
-    """Cloud Functionのエントリポイント（HTTP/PubSubトリガー）。
-
-    Args:
-        request (object, optional): Cloud Functionのリクエストオブジェクト。
+def weather_ingestion_handler() -> None:
+    """気象データの取得・バリデーション・BigQuery アップロードを実行する。
 
     Returns:
-        tuple[str, int]: レスポンスメッセージとHTTPステータスコード。
+        None
+
+    Raises:
+        RuntimeError: GCP_PROJECT_ID が未設定の場合。
+        google.cloud.exceptions.GoogleCloudError: BigQuery 操作が失敗した場合。
     """
     project_id = os.getenv("GCP_PROJECT_ID")
     dataset_id = os.getenv("BQ_DATASET_ID", "weather_data")
     table_id = os.getenv("BQ_TABLE_ID", "daily_stats")
 
     if not project_id:
-        logger.error("GCP_PROJECT_ID が設定されていません。")
-        return "Error: GCP_PROJECT_ID not set", 500
+        raise RuntimeError("GCP_PROJECT_ID が設定されていません。")
 
     locations = get_locations_from_env()
     target_date = datetime.now() - timedelta(days=1)
@@ -43,11 +40,7 @@ def weather_ingestion_handler(request: object = None) -> tuple[str, int]:
     client = bigquery.Client(project=project_id)
     table_full_id = f"{project_id}.{dataset_id}.{table_id}"
 
-    try:
-        delete_month_data(client, table_full_id, year, month)
-    except Exception as e:
-        logger.exception("既存データの削除に失敗しました。")
-        return f"Error: {str(e)}", 500
+    delete_month_data(client, table_full_id, year, month)
 
     all_dfs = []
     for loc in locations:
@@ -63,20 +56,23 @@ def weather_ingestion_handler(request: object = None) -> tuple[str, int]:
             logger.exception("%s のデータ取得に失敗しました。", loc.block_name)
 
     if not all_dfs:
-        return f"{year}/{month} のアップロード対象データがありません", 200
+        logger.warning(
+            "%04d/%02d のアップロード対象データがありません。", year, month
+        )
+        return
 
     combined_df = pd.concat(all_dfs, ignore_index=True)
-
-    try:
-        upload_to_bigquery(
-            combined_df, project_id, dataset_id, table_id, table_full_id
-        )
-    except Exception as e:
-        logger.exception("BigQuery へのアップロードに失敗しました。")
-        return f"Error: {str(e)}", 500
-
-    return f"Successfully updated {table_full_id} for {year}/{month}", 200
+    upload_to_bigquery(
+        combined_df, project_id, dataset_id, table_id, table_full_id
+    )
+    logger.info(
+        "%s を %04d/%02d のデータで更新しました。", table_full_id, year, month
+    )
 
 
 if __name__ == "__main__":
-    print(weather_ingestion_handler())
+    try:
+        weather_ingestion_handler()
+    except Exception:
+        logger.exception("処理が失敗しました。")
+        sys.exit(1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,14 +31,14 @@ SAMPLE_DF = pd.DataFrame(
 class TestWeatherIngestionHandler:
     """weather_ingestion_handler のテスト。"""
 
-    def test_returns_500_when_no_project_id(self, monkeypatch):
-        """GCP_PROJECT_ID 未設定時はステータス 500 を返す。"""
+    def test_raises_when_no_project_id(self, monkeypatch):
+        """GCP_PROJECT_ID 未設定時は RuntimeError を送出する。"""
         monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
-        _, status = weather_ingestion_handler()
-        assert status == 500
+        with pytest.raises(RuntimeError, match="GCP_PROJECT_ID"):
+            weather_ingestion_handler()
 
-    def test_returns_200_with_valid_data(self, monkeypatch):
-        """正常系（データあり）はステータス 200 を返す。"""
+    def test_succeeds_with_valid_data(self, monkeypatch):
+        """正常系（データあり）は例外を送出せずに完了する。"""
         monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
         with (
             mock.patch("main.bigquery.Client"),
@@ -51,8 +51,7 @@ class TestWeatherIngestionHandler:
             ),
             mock.patch("main.upload_to_bigquery"),
         ):
-            _, status = weather_ingestion_handler()
-        assert status == 200
+            weather_ingestion_handler()  # 例外が出なければ成功
 
     def test_upload_is_called_with_data(self, monkeypatch):
         """データあり時は upload_to_bigquery が呼ばれる。"""
@@ -71,8 +70,8 @@ class TestWeatherIngestionHandler:
             weather_ingestion_handler()
         mock_upload.assert_called_once()
 
-    def test_returns_200_when_no_data(self, monkeypatch):
-        """全地点でデータなし時はステータス 200 を返す。"""
+    def test_succeeds_when_no_data(self, monkeypatch):
+        """全地点でデータなし時は例外を送出せず、upload は呼ばれない。"""
         monkeypatch.setenv("GCP_PROJECT_ID", "test-project")
         with (
             mock.patch("main.bigquery.Client"),
@@ -86,6 +85,5 @@ class TestWeatherIngestionHandler:
             ),
             mock.patch("main.upload_to_bigquery") as mock_upload,
         ):
-            _, status = weather_ingestion_handler()
-        assert status == 200
+            weather_ingestion_handler()  # 例外が出なければ成功
         mock_upload.assert_not_called()


### PR DESCRIPTION
## Summary

- `Dockerfile` を追加（uv ベース、`python:3.14-slim`）
- `.dockerignore` を追加（`.venv/`・`.vscode/`・`CLAUDE.md`・キャッシュ等を除外）
- `requirements.txt` を削除（`pyproject.toml` + `uv.lock` に一本化）
- `src/main.py` を Cloud Run Jobs 向けに変更
  - HTTP レスポンス `(str, int)` の返却をやめ、戻り値を `None` に変更
  - エラー時は例外を送出し、`__main__` ブロックで `sys.exit(1)` に変換
- `tests/test_main.py` を新しいインターフェースに合わせて更新

## Dockerfile

```dockerfile
FROM python:3.14-slim
COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
WORKDIR /app
COPY pyproject.toml uv.lock ./
RUN uv sync --frozen --no-dev
COPY src/ ./src/
ENV PYTHONPATH=/app/src
CMD ["uv", "run", "python", "src/main.py"]
```

## デプロイ方法（Cloud Run Jobs）

```bash
# イメージビルド・プッシュ
docker build -t gcr.io/<PROJECT_ID>/life-weather .
docker push gcr.io/<PROJECT_ID>/life-weather

# Cloud Run Jobs 作成
gcloud run jobs create life-weather \
  --image gcr.io/<PROJECT_ID>/life-weather \
  --set-env-vars GCP_PROJECT_ID=<PROJECT_ID>
```

Close #41

## Test plan

- [ ] `uv run ruff check src/` でエラーなし
- [ ] `uv run pytest tests/ -q` で全 58 件がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)