### PR TITLE
refactor: models.py の NaN チェックを math.isnan に変更して pandas 依存を除去する

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-import pandas as pd
+import math
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -97,7 +97,7 @@ class WeatherRecord(BaseModel):
         Returns:
             Any: クリーニング後の文字列。欠損値の場合は None を返す。
         """
-        if value is None or (isinstance(value, float) and pd.isna(value)):
+        if value is None or (isinstance(value, float) and math.isnan(value)):
             return None
 
         str_val = str(value)

--- a/src/models.py
+++ b/src/models.py
@@ -1,8 +1,8 @@
 """気象庁の気象データの Pydantic モデル定義。"""
 
+import math
 from typing import Any
 
-import math
 from pydantic import BaseModel, Field, field_validator
 
 


### PR DESCRIPTION
## Summary

- `src/models.py` の `import pandas as pd` を `import math` に変更
- `pd.isna(value)` を `math.isnan(value)` に変更
- `models.py` から pandas 依存を完全に除去

## Related Issue

Closes #42

## Test plan

- [x] 既存のテスト 58 件がすべてパスすることを確認（`uv run pytest tests/ -v`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)