### PR TITLE
fix: scraper.py の except 句を Python 3 構文に修正する

### DIFF
--- a/src/scraper.py
+++ b/src/scraper.py
@@ -123,7 +123,7 @@ def _validate_weather_records(
             if any(v is not None for v in obs_values):
                 validated_records.append(data_dict)
 
-        except ValueError, ValidationError:
+        except (ValueError, ValidationError):
             continue
 
     return validated_records


### PR DESCRIPTION
## Summary

- `scraper.py:126` の `except ValueError, ValidationError:` を Python 3 の正しい構文 `except (ValueError, ValidationError):` に修正した
- この構文エラーにより、ファイルを import した時点で `SyntaxError` が発生していた

## Related Issue

Closes #49

## Test plan

- [x] `python -m py_compile src/scraper.py` で構文エラーがないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)