### PR TITLE
chore: pyproject.toml から未使用の jedi 依存を除去する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.14"
 dependencies = [
     "beautifulsoup4>=4.14.3",
     "google-cloud-bigquery>=3.40.1",
-    "jedi>=0.19.2",
     "lxml>=6.0.2",
     "pandas>=3.0.1",
     "pandas-gbq>=0.34.0",

--- a/uv.lock
+++ b/uv.lock
@@ -344,25 +344,12 @@ wheels = [
 ]
 
 [[package]]
-name = "jedi"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "parso" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
-]
-
-[[package]]
 name = "life-weather"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "google-cloud-bigquery" },
-    { name = "jedi" },
     { name = "lxml" },
     { name = "pandas" },
     { name = "pandas-gbq" },
@@ -382,7 +369,6 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "google-cloud-bigquery", specifier = ">=3.40.1" },
-    { name = "jedi", specifier = ">=0.19.2" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "pandas-gbq", specifier = ">=0.34.0" },
@@ -539,15 +525,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/94/6e1bcf1e6413772308f092a1facf13f487552df26c7101707977925cbdbe/pandas_gbq-0.34.0.tar.gz", hash = "sha256:f1b06d9bfe0135ab666ff02c57d879b78977c06effb37dd3eca54694a53d7ec3", size = 79015, upload-time = "2026-03-05T22:28:19.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/44/f64798212dc0254281639d83c99edb98ce225e8890b596040f1eb563fb73/pandas_gbq-0.34.0-py3-none-any.whl", hash = "sha256:05c8856bc11806237f16e5b042554d2216a7093f8d97b764da60e0208900e638", size = 50736, upload-time = "2026-03-05T22:28:17.45Z" },
-]
-
-[[package]]
-name = "parso"
-version = "0.8.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `pyproject.toml` から未使用の `jedi>=0.19.2` を削除した
- `uv lock` により、`jedi` が依存していた `parso` も合わせて除去された（計2パッケージ削減）

## Related Issue

Closes #52

## Test plan

- [x] `uv run pytest` で全58件パスを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)