### PR TITLE
fix: except Exception の捕捉範囲を適切な例外型に絞り、ログを追加する

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -4,6 +4,8 @@ import json
 import logging
 import os
 
+from pydantic import ValidationError
+
 from models import Location
 
 logger = logging.getLogger(__name__)
@@ -35,7 +37,7 @@ def parse_location_json(locations_json: str) -> list[Location]:
     try:
         raw_list = json.loads(locations_json)
         return [Location.model_validate(item) for item in raw_list]
-    except Exception as e:
+    except (json.JSONDecodeError, ValidationError) as e:
         logger.error("JMA_LOCATIONSのパースに失敗: %s", e)
         return []
 

--- a/src/download_history.py
+++ b/src/download_history.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
+import requests
 from dateutil.relativedelta import relativedelta
 
 from config import get_locations_from_env
@@ -74,7 +75,7 @@ def download_5years_history() -> None:
 
                 time.sleep(1)
 
-            except Exception as e:
+            except (requests.HTTPError, ValueError) as e:
                 logger.error(
                     "%04d/%02d %s の取得中にエラーが発生しました: %s",
                     year,

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import sys
 from datetime import datetime, timedelta
 
 import pandas as pd
+import requests
 from google.cloud import bigquery
 
 from bigquery_client import delete_month_data, upload_to_bigquery
@@ -52,7 +53,7 @@ def weather_ingestion_handler() -> None:
             )
             if not df.empty:
                 all_dfs.append(df)
-        except Exception:
+        except requests.HTTPError, ValueError:
             logger.exception("%s のデータ取得に失敗しました。", loc.block_name)
 
     if not all_dfs:

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -123,7 +123,21 @@ def _validate_weather_records(
             if any(v is not None for v in obs_values):
                 validated_records.append(data_dict)
 
-        except ValueError, ValidationError:
+        except ValueError:
+            logger.debug(
+                "%04d/%02d 日付パース失敗のためスキップ: %s",
+                year,
+                month,
+                day_val,
+            )
+            continue
+        except ValidationError as e:
+            logger.debug(
+                "%04d/%02d バリデーション失敗のためスキップ: %s",
+                year,
+                month,
+                e,
+            )
             continue
 
     return validated_records


### PR DESCRIPTION
## Summary

- `config.py`: `except Exception` → `except (json.JSONDecodeError, ValidationError)` に絞る
- `main.py`: スクレイパー呼び出し箇所の `except Exception` → `except (requests.HTTPError, ValueError)` に絞る（`__main__` の最上位ハンドラは安全網として `Exception` を維持）
- `download_history.py`: 同様に `except (requests.HTTPError, ValueError)` に絞る
- `scraper.py`: `except ValueError, ValidationError` を2つに分割し、それぞれにデバッグログを追加する

## Related Issue

Closes #50

## Test plan

- [x] `uv run ruff check src/` でエラーなし
- [x] `uv run pytest` で全58件パスを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)