### PR TITLE
refactor: ロギング初期化を setup_logging() に切り出してコード全体で統一する

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -11,6 +11,22 @@ from models import Location
 logger = logging.getLogger(__name__)
 
 
+def setup_logging() -> None:
+    """ロギングの初期設定を行う。
+
+    エントリポイント（main.py, download_history.py）から1回だけ呼び出す。
+    各モジュールは logging.getLogger(__name__) のみ使用し、
+    この関数は呼び出さない。
+
+    Returns:
+        None
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    )
+
+
 def get_env_str(key: str, default: str = "") -> str:
     """環境変数を文字列として取得する。
 

--- a/src/download_history.py
+++ b/src/download_history.py
@@ -9,13 +9,10 @@ import pandas as pd
 import requests
 from dateutil.relativedelta import relativedelta
 
-from config import get_locations_from_env
+from config import get_locations_from_env, setup_logging
 from scraper import fetch_and_validate_weather
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
+setup_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -10,10 +10,10 @@ import requests
 from google.cloud import bigquery
 
 from bigquery_client import delete_month_data, upload_to_bigquery
-from config import get_locations_from_env
+from config import get_locations_from_env, setup_logging
 from scraper import fetch_and_validate_weather
 
-logging.basicConfig(level=logging.INFO)
+setup_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,15 @@
 """config.py のユニットテスト。"""
 
+import logging
+from unittest import mock
+
 import pytest
 
 from config import (
     get_default_locations,
     get_locations_from_env,
     parse_location_json,
+    setup_logging,
 )
 from models import Location
 
@@ -110,3 +114,33 @@ class TestGetLocationsFromEnv:
         monkeypatch.setenv("JMA_LOCATIONS", "invalid json")
         result = get_locations_from_env()
         assert len(result) == 6
+
+
+class TestSetupLogging:
+    """setup_logging のテスト。
+
+    pytest が自身の LogCaptureHandler をルートロガーに追加するため、
+    basicConfig() の「ハンドラーがなければ設定する」という仕様と干渉する。
+    そのためモックを使って basicConfig の呼び出し内容を検証する。
+    """
+
+    def test_calls_basicconfig_with_info_level(self):
+        """logging.basicConfig を INFO レベルで呼び出す。"""
+        with mock.patch("logging.basicConfig") as mock_basicconfig:
+            setup_logging()
+            mock_basicconfig.assert_called_once()
+            assert mock_basicconfig.call_args.kwargs["level"] == logging.INFO
+
+    def test_format_includes_module_name(self):
+        """フォーマットに %(name)s（モジュール名）が含まれる。"""
+        with mock.patch("logging.basicConfig") as mock_basicconfig:
+            setup_logging()
+            fmt = mock_basicconfig.call_args.kwargs["format"]
+            assert "%(name)s" in fmt
+
+    def test_format_includes_timestamp(self):
+        """フォーマットに %(asctime)s（タイムスタンプ）が含まれる。"""
+        with mock.patch("logging.basicConfig") as mock_basicconfig:
+            setup_logging()
+            fmt = mock_basicconfig.call_args.kwargs["format"]
+            assert "%(asctime)s" in fmt


### PR DESCRIPTION
## Summary

- `config.py` に `setup_logging()` を追加し、フォーマット統一・ルートロガー設定を一元管理する
- `main.py`・`download_history.py` の `logging.basicConfig()` 直接呼び出しを `setup_logging()` に置き換える
- ライブラリモジュール（`scraper.py`・`bigquery_client.py`・`config.py`）は `getLogger(__name__)` のみを使用する設計を維持する
- `tests/test_config.py` に `TestSetupLogging` クラスを追加（pytest の `LogCaptureHandler` 干渉を避けるためモックベースで実装）

## Related Issue

Closes #53

## Test plan

- [x] `uv run ruff check src/` でエラーなし
- [x] `uv run pytest` で全61件パスを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)