### PR TITLE
refactor: download_history.py の関数を責務ごとに分割する

### DIFF
--- a/src/download_history.py
+++ b/src/download_history.py
@@ -10,41 +10,53 @@ import requests
 from dateutil.relativedelta import relativedelta
 
 from config import get_locations_from_env, setup_logging
+from models import Location
 from scraper import fetch_and_validate_weather
 
 setup_logging()
 logger = logging.getLogger(__name__)
 
+_DEFAULT_OUTPUT = (
+    Path(__file__).parent.parent / "data" / "weather_history_5y.csv"
+)
 
-def download_5years_history() -> None:
-    """現在から遡って5年分のデータを全地点分取得し、1つのCSVに保存する。
 
-    取得対象地点は環境変数 JMA_LOCATIONS または
-    デフォルト地点リストから取得する。
-    出力先は `../data/weather_history_5y.csv`（utf-8-sig エンコード）。
-    気象庁サーバーへの負荷軽減のため、地点ごとに1秒の待機を挟む。
+def _build_month_range(years: int) -> list[tuple[int, int]]:
+    """現在から遡って指定年数分の (year, month) リストを返す。
+
+    Args:
+        years (int): 遡る年数。
 
     Returns:
-        None
+        list[tuple[int, int]]: 開始月から現在月までの (year, month) のリスト。
     """
-    locations = get_locations_from_env()
-
     end_date = datetime.now()
-    start_date = end_date - relativedelta(years=5)
+    start_date = end_date - relativedelta(years=years)
+    months = []
+    current = start_date
+    while current <= end_date:
+        months.append((current.year, current.month))
+        current += relativedelta(months=1)
+    return months
 
-    logger.info(
-        "%s から %s までのデータを取得します。（%d地点）",
-        start_date.strftime("%Y/%m"),
-        end_date.strftime("%Y/%m"),
-        len(locations),
-    )
 
+def _fetch_all(
+    locations: list[Location],
+    month_range: list[tuple[int, int]],
+) -> list[pd.DataFrame]:
+    """地点 × 月の組み合わせでデータを取得し、DataFrame のリストを返す。
+
+    気象庁サーバーへの負荷軽減のため、地点ごとに1秒の待機を挟む。
+
+    Args:
+        locations (list[Location]): 取得対象の観測地点リスト。
+        month_range (list[tuple[int, int]]): 取得対象の (year, month) リスト。
+
+    Returns:
+        list[pd.DataFrame]: 取得に成功した DataFrame のリスト。
+    """
     all_dfs = []
-    current_date = start_date
-
-    while current_date <= end_date:
-        year, month = current_date.year, current_date.month
-
+    for year, month in month_range:
         for loc in locations:
             try:
                 df = fetch_and_validate_weather(
@@ -52,7 +64,6 @@ def download_5years_history() -> None:
                     year=year,
                     month=month,
                 )
-
                 if not df.empty:
                     all_dfs.append(df)
                     logger.info(
@@ -69,9 +80,7 @@ def download_5years_history() -> None:
                         month,
                         loc.block_name,
                     )
-
                 time.sleep(1)
-
             except (requests.HTTPError, ValueError) as e:
                 logger.error(
                     "%04d/%02d %s の取得中にエラーが発生しました: %s",
@@ -80,21 +89,58 @@ def download_5years_history() -> None:
                     loc.block_name,
                     e,
                 )
+    return all_dfs
 
-        current_date += relativedelta(months=1)
+
+def _save_csv(df: pd.DataFrame, output_path: Path) -> None:
+    """DataFrame を CSV ファイルに保存する。
+
+    utf-8-sig エンコードを使用することで Excel での文字化けを防ぐ。
+
+    Args:
+        df (pd.DataFrame): 保存対象の DataFrame。
+        output_path (Path): 保存先のファイルパス。
+
+    Returns:
+        None
+    """
+    df.to_csv(output_path, index=False, encoding="utf-8-sig")
+    logger.info("-" * 30)
+    logger.info("全ての処理が完了しました。")
+    logger.info("保存先: %s", output_path)
+    logger.info("合計レコード数: %d 行", len(df))
+
+
+def download_5years_history(output_path: Path = _DEFAULT_OUTPUT) -> None:
+    """現在から遡って5年分のデータを全地点分取得し、CSVに保存する。
+
+    取得対象地点は環境変数 JMA_LOCATIONS または
+    デフォルト地点リストから取得する。
+
+    Args:
+        output_path (Path): 保存先のファイルパス。
+            デフォルトは `../data/weather_history_5y.csv`。
+
+    Returns:
+        None
+    """
+    locations = get_locations_from_env()
+    month_range = _build_month_range(years=5)
+
+    logger.info(
+        "%04d/%02d から %04d/%02d までのデータを取得します。（%d地点）",
+        month_range[0][0],
+        month_range[0][1],
+        month_range[-1][0],
+        month_range[-1][1],
+        len(locations),
+    )
+
+    all_dfs = _fetch_all(locations, month_range)
 
     if all_dfs:
         master_df = pd.concat(all_dfs, ignore_index=True)
-        output_file = (
-            Path(__file__).parent.parent / "data" / "weather_history_5y.csv"
-        )
-        # utf-8-sig を使うとExcelで開いた際の文字化けを防げます
-        master_df.to_csv(output_file, index=False, encoding="utf-8-sig")
-
-        logger.info("-" * 30)
-        logger.info("全ての処理が完了しました。")
-        logger.info("保存先: %s", output_file)
-        logger.info("合計レコード数: %d 行", len(master_df))
+        _save_csv(master_df, output_path)
     else:
         logger.error("データが1件も取得できませんでした。")
 


### PR DESCRIPTION
## Summary

- `download_5years_history()` から以下の3つの内部関数に分割した
  - `_build_month_range(years)`: 現在から遡って指定年数分の `(year, month)` リストを生成する
  - `_fetch_all(locations, month_range)`: 地点 × 月のループでスクレイピングを実行する
  - `_save_csv(df, output_path)`: DataFrame を utf-8-sig エンコードで CSV に保存する
- `download_5years_history()` に `output_path` 引数を追加し、デフォルト値で既存の挙動を維持する
- `if __name__ == "__main__":` によるローカル実行の仕様は変更なし

## Related Issue

Closes #54

## Test plan

- [x] `uv run ruff check src/` でエラーなし
- [x] `uv run pytest` で全61件パスを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)